### PR TITLE
Add dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ mcpo is a dead-simple proxy that takes an MCP server command and makes it access
 
 No custom protocol. No glue code. No hassle.
 
+## 🤔 Why Use mcpo Instead of Native MCP?
+
+MCP servers usually speak over raw stdio, which is:
+
+- 🔓 Inherently insecure
+- ❌ Incompatible with most tools
+- 🧩 Missing standard features like docs, auth, error handling, etc.
+
+mcpo solves all of that—without extra effort:
+
+- ✅ Works instantly with OpenAPI tools, SDKs, and UIs
+- 🛡 Adds security, stability, and scalability using trusted web standards
+- 🧠 Auto-generates interactive docs for every tool, no config needed
+- 🔌 Uses pure HTTP—no sockets, no glue code, no surprises
+
+What feels like "one more step" is really fewer steps with better outcomes.
+
+mcpo makes your AI tools usable, secure, and interoperable—right now, with zero hassle.
+
 ## 🚀 Quick Usage
 
 We recommend using uv for lightning-fast startup and zero config.

--- a/README.md
+++ b/README.md
@@ -6,25 +6,6 @@ mcpo is a dead-simple proxy that takes an MCP server command and makes it access
 
 No custom protocol. No glue code. No hassle.
 
-## 🤔 Why Use mcpo Instead of Native MCP?
-
-MCP servers usually speak over raw stdio, which is:
-
-- 🔓 Inherently insecure
-- ❌ Incompatible with most tools
-- 🧩 Missing standard features like docs, auth, error handling, etc.
-
-mcpo solves all of that—without extra effort:
-
-- ✅ Works instantly with OpenAPI tools, SDKs, and UIs
-- 🛡 Adds security, stability, and scalability using trusted web standards
-- 🧠 Auto-generates interactive docs for every tool, no config needed
-- 🔌 Uses pure HTTP—no sockets, no glue code, no surprises
-
-What feels like "one more step" is really fewer steps with better outcomes.
-
-mcpo makes your AI tools usable, secure, and interoperable—right now, with zero hassle.
-
 ## 🚀 Quick Usage
 
 We recommend using uv for lightning-fast startup and zero config.
@@ -47,6 +28,7 @@ uvx mcpo --port 8000 -- uvx mcp-server-time --local-timezone=America/New_York
 ```
 
 That’s it. Your MCP tool is now available at http://localhost:8000 with a generated OpenAPI schema — test it live at [http://localhost:8000/docs](http://localhost:8000/docs).
+
 
 ### 🔄 Using a Config File
 
@@ -80,6 +62,28 @@ Each tool will be accessible under its own unique route, e.g.:
 - http://localhost:8000/time
 
 Each with a dedicated OpenAPI schema and proxy handler. Access full schema UI at: `http://localhost:8000/<tool>/docs`  (e.g. /memory/docs, /time/docs)
+
+## 🐋 Docker
+
+mcpo can be run in Docker with the enclosed dockerfile. Mount a volume containing config.json to /app and add servers to install at /servers. Each time the container launches it will look for new tools it has not yet installed (in the /servers directory) and install them. Use the pip installation method when adding new tools to the config.json for use in this container.
+
+If no servers are added and/or if config.json doesn't exist, the container will load the example config and clone "time" and "fetch" from github.
+
+Example docker-compose:
+
+```yaml
+services:
+  mcpo:
+    build:
+      context: .
+      dockerfile: dockerfile
+    container_name: mcpo
+    ports:
+      - "8080:8000"
+    volumes:
+      - ./app:/app
+      - ./servers:/servers
+```
 
 ## 🔧 Requirements
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# This script checks /servers for any new subfolders. If it finds
+# a subfolder whose requirements have not yet been installed,
+# it installs them, then finally runs mcpo (or whatever command is passed).
+# In the event that /servers is empty, all default mcp servers are copied and the example config file is used.
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+# If /servers is empty, clone the mcp servers repo and copy its "src" directory
+DIR="/servers"
+if [ ! -d "$DIR" ]; then
+    echo "$DIR does not exist. Creating it..."
+    mkdir -p "$DIR"
+fi
+if [ -d "$DIR" ] && [ -z "$(ls -A "$DIR")" ]; then
+    # Servers directory is empty
+    echo "$DIR is empty, cloning example mcp servers..."
+    git clone --depth 1 --filter=blob:none --sparse https://github.com/modelcontextprotocol/servers.git /servers/tmp
+    git -C /servers/tmp sparse-checkout init --cone
+    git -C /servers/tmp sparse-checkout set src/time src/fetch
+    mv /servers/tmp/src/* /servers/
+    echo "listing /servers dir"
+    ls /servers
+    echo "listing /servers subdirs"
+    ls /servers/*
+    rm -rf /servers/tmp 
+    echo "Cloned and copied servers into /servers."
+    if [ -f "/app/config.json" ]; then
+      echo "Config supplied but there are no servers! Reverting to example config and backing up current config."
+      mv -f /app/config.json /app/backup.config.json
+    else
+      echo "No config supplied, using example config."
+    fi
+    cp /usr/local/bin/example.config.json /app/config.json
+else
+    # Servers directory is not empty
+    echo "$DIR exists and is not empty. Doing nothing."
+fi
+
+# Directory to track which /servers/ subfolders we've installed
+INSTALLED_DIR="/usr/local/bin/installed_servers"
+
+# Ensure the tracking directory exists
+mkdir -p "$INSTALLED_DIR"
+
+# Temporary file to combine new requirements
+NEW_REQS_FILE=$(mktemp)
+
+# For each subfolder in /servers, if not yet installed, add its requirements
+if [ -d /servers ]; then
+    for folder in /servers/*; do
+        if [ -d "$folder" ]; then
+            subfolder="$(basename "$folder")"
+            # Install the actual server
+            echo "$folder" >> "$NEW_REQS_FILE"
+            # If we haven't installed this subfolder yet
+            if [ ! -f "$INSTALLED_DIR/$subfolder" ]; then
+                # If it has a requirements.txt, add to the combined file
+                if [ -f "$folder/requirements.txt" ]; then
+                    for l in "$folder/requirements.txt"; do (cat "${l}"; echo) >> "$NEW_REQS_FILE"; done
+                fi
+
+                # Mark this subfolder as installed
+                touch "$INSTALLED_DIR/$subfolder"
+            fi
+        fi
+    done
+fi
+
+# If NEW_REQS_FILE is non-empty, install everything in one go
+if [ -s "$NEW_REQS_FILE" ]; then
+    pip install -r "$NEW_REQS_FILE"
+fi
+
+# Clean up
+rm "$NEW_REQS_FILE"
+
+# Finally, execute the command that was passed in (defaults to "mcpo --config $CONFIG_PATH" from the Dockerfile)
+exec "$@"

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,40 @@
+
+# Use the official Python image as a base
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    CONFIG_PATH=/app/config.json \
+    PORT=8000
+
+# Create and set the working directory
+WORKDIR /app
+
+# Install git (and clean up)
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create servers directory
+RUN mkdir /servers
+
+# Install mcpo and uv for managing Python packages
+RUN pip install uvx npx mcpo
+
+# Copy the entrypoint script into the container
+COPY docker-entrypoint.sh /usr/local/bin/
+
+# Copy the example configuration JSON into the container in case the user does not supply one
+COPY example.config.json /usr/local/bin/
+
+# Make sure the entrypoint script is executable
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Expose the port mcpo will run on
+EXPOSE $PORT
+
+# Use the entrypoint script
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# Command to run mcpo with the specified configuration
+CMD mcpo --config "$CONFIG_PATH"

--- a/example.config.json
+++ b/example.config.json
@@ -1,0 +1,12 @@
+{
+    "mcpServers": {
+      "fetch": {
+        "command": "python",
+        "args": ["-m", "mcp_server_fetch"]
+      },
+      "time": {
+        "command": "python",
+        "args": ["-m", "mcp_server_time"]
+      }
+    }
+  }


### PR DESCRIPTION
I added a dockerfile that allows the user to bundle/configure the MCP servers they want and run them all in one container. This dockerfile defaults to installing only "time" and "fetch" if no servers are present. I've also included an example config which is used if there is no config file present when running in docker. I updated the readme accordingly.