### PR TITLE
FIX: Enable SSL option

### DIFF
--- a/src/mcpo/__init__.py
+++ b/src/mcpo/__init__.py
@@ -41,6 +41,12 @@ def main(
     version: Annotated[
         Optional[str], typer.Option("--version", "-v", help="Server version")
     ] = None,
+    ssl_certfile: Annotated[
+        Optional[str], typer.Option("--ssl-certfile", "-t", help="SSL certfile")
+    ] = None,
+    ssl_keyfile: Annotated[
+        Optional[str], typer.Option("--ssl-keyfile", "-k",  help="SSL keyfile")
+    ] = None,
 ):
     server_command = None
     if not config:
@@ -87,6 +93,8 @@ def main(
             description=description,
             version=version,
             server_command=server_command,
+            ssl_certfile=ssl_certfile,
+            ssl_keyfile=ssl_keyfile,
         )
     )
 

--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -157,9 +157,11 @@ async def run(
         kwargs.get("description") or "Automatically generated API from MCP Tool Schemas"
     )
     version = kwargs.get("version") or "1.0"
+    ssl_certfile = kwargs.get("ssl_certfile")
+    ssl_keyfile= kwargs.get("ssl_keyfile")
 
     main_app = FastAPI(
-        title=name, description=description, version=version, lifespan=lifespan
+        title=name, description=description, version=version, ssl_certfile=ssl_certfile, ssl_keyfile=ssl_keyfile, lifespan=lifespan
     )
 
     main_app.add_middleware(
@@ -212,7 +214,7 @@ async def run(
     else:
         raise ValueError("You must provide either server_command or config.")
 
-    config = uvicorn.Config(app=main_app, host=host, port=port, log_level="info")
+    config = uvicorn.Config(app=main_app, host=host, port=port, ssl_certfile=ssl_certfile , ssl_keyfile=ssl_keyfile ,log_level="info")
     server = uvicorn.Server(config)
 
     await server.serve()


### PR DESCRIPTION
FIX: Enable SSL option
......................................

Added SSL option to uvicorn run.
Added optional params: --ssl-certfile="certfile_path" & --ssl-keyfile="keyfile_path"

![MCP-Config-server-ssl3](https://github.com/user-attachments/assets/2d6e406d-e9b3-40f1-abf8-1bb7d4b67908)

![MCP-Config-server-ssl](https://github.com/user-attachments/assets/7398033d-4d3d-4fdf-992a-03535418eb2b)

![MCP-Config-server-ssl1](https://github.com/user-attachments/assets/198baf4d-52b8-44c4-b9b2-40147234e6de)

![MCP-Config-server-ssl2](https://github.com/user-attachments/assets/3f9d318e-4548-4b1c-9444-8c2b74dc6c96)
