### PR TITLE
fix: resolve mcpo startup fail when mcp tool parameters are missing

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -58,7 +58,8 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
         # Build Pydantic model
         model_fields = {}
         required_fields = schema.get("required", [])
-        for param_name, param_schema in schema["properties"].items():
+        properties = schema.get("properties", {})
+        for param_name, param_schema in properties.items():
             param_type = param_schema.get("type", "string")
             param_desc = param_schema.get("description", "")
             python_type = get_python_type(param_type)


### PR DESCRIPTION
---

# Pull Request

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Fixed an issue where mcpo wouldn’t start if mcp tool parameters were not set.
- [x] **Changelog:** Ensure a changelog entry following the format of [[Keep a Changelog](https://keepachangelog.com/)](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** No new dependencies introduced.
- [x] **Testing:** The issue was tested and verified locally by simulating missing parameters for the mcp tool.
- [x] **Code review:** I have reviewed the code and ensured it meets the project's coding standards.
- [x] **Prefix:** `fix`

# Changelog Entry

### Fixed

- Fixed an issue where mcpo would fail to start when mcp tool parameters were missing. Now mcpo handles missing parameters by using default values or providing appropriate error messages.


### Reproduction

https://github.com/chizukicn/mcp-ts-example

**mcp tool code**
```typescript
import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
// Create an MCP server
const server = new McpServer({
  name: "My Server",
  version: "1.0.0",
});

server.tool("nothing", "do nothing",  () => {
  return {
    content: [{
      type: "text",
      text: `什么也没干`
    }]
  };
});

const transport = new StdioServerTransport();

server.connect(transport);

```

**config.json**
```json
{
  "mcpServers": {
    "ts-mcp": {
      "command": "tsx",
      "args": ["src/index.ts"]
    }
  }
}
```

### Screenshots or Videos

- <img width="1004" alt="image" src="https://github.com/user-attachments/assets/01b600ac-898f-45a6-8a72-a1e3baaf5eb8" />
