### PR TITLE
fix the problem when split env variables with '='

### DIFF
--- a/src/mcpo/__init__.py
+++ b/src/mcpo/__init__.py
@@ -77,7 +77,7 @@ def main(
     env_dict = {}
     if env:
         for var in env:
-            key, value = env.split("=", 1)
+            key, value = var.split("=", 1)
             env_dict[key] = value
 
     # Set environment variables


### PR DESCRIPTION
When starting with the 'env', like `uvx mcpo --env SOME_VAR=somevalue -- mycommand`, an error will pop out: `AttributeError: 'list' object has no attribute 'split'`. Maybe that's because in the `__init__`, the split function is called on the `env` variable, instead of `var` variable.