### PR TITLE
fix: wait for MCP server tools to be ready before listing

### DIFF
--- a/src/mcpo/__init__.py
+++ b/src/mcpo/__init__.py
@@ -61,6 +61,12 @@ def main(
     path_prefix: Annotated[
         Optional[str], typer.Option("--path-prefix", help="URL prefix")
     ] = None,
+    tools_timeout: Annotated[
+        Optional[int], typer.Option("--tools-timeout", help="Timeout for waiting tools")
+    ] = 15,
+    tools_interval: Annotated[
+        Optional[int], typer.Option("--tools-interval", help="Polling interval for tools")
+    ] = 1,
 ):
     server_command = None
     if not config_path:
@@ -131,6 +137,8 @@ def main(
             ssl_certfile=ssl_certfile,
             ssl_keyfile=ssl_keyfile,
             path_prefix=path_prefix,
+            tools_timeout=tools_timeout,
+            tools_interval=tools_interval,
         )
     )
 

--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -12,11 +12,16 @@ from mcp.client.stdio import stdio_client
 from starlette.routing import Mount
 
 
-from mcpo.utils.main import get_model_fields, get_tool_handler
+from mcpo.utils.main import get_model_fields, get_tool_handler, wait_list_tools
 from mcpo.utils.auth import get_verify_api_key, APIKeyMiddleware
 
 
-async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
+async def create_dynamic_endpoints(
+    app: FastAPI,
+    api_dependency=None,
+    tools_timeout: int = 15,
+    tools_interval: int = 1,
+):
     session: ClientSession = app.state.session
     if not session:
         raise ValueError("Session is not initialized in the app state.")
@@ -30,7 +35,11 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
         )
         app.version = server_info.version or app.version
 
-    tools_result = await session.list_tools()
+    try:
+        tools_result = await wait_list_tools(session, timeout=tools_timeout, interval=tools_interval)
+    except Exception as e:
+        raise RuntimeError(f"Failed to retrieve tools from MCP server: {e}")
+
     tools = tools_result.tools
 
     for tool in tools:
@@ -81,6 +90,8 @@ async def lifespan(app: FastAPI):
 
     args = args if isinstance(args, list) else [args]
     api_dependency = getattr(app.state, "api_dependency", None)
+    tools_timeout = getattr(app.state, "tools_timeout", 5)
+    tools_interval = getattr(app.state, "tools_interval", 1)
 
     if (server_type == "stdio" and not command) or (
         server_type == "sse" and not args[0]
@@ -104,7 +115,12 @@ async def lifespan(app: FastAPI):
             async with stdio_client(server_params) as (reader, writer):
                 async with ClientSession(reader, writer) as session:
                     app.state.session = session
-                    await create_dynamic_endpoints(app, api_dependency=api_dependency)
+                    await create_dynamic_endpoints(
+                        app,
+                        api_dependency=api_dependency,
+                        tools_timeout=tools_timeout,
+                        tools_interval=tools_interval,
+                    )
                     yield
         if server_type == "sse":
             async with sse_client(url=args[0], sse_read_timeout=None) as (
@@ -113,7 +129,12 @@ async def lifespan(app: FastAPI):
             ):
                 async with ClientSession(reader, writer) as session:
                     app.state.session = session
-                    await create_dynamic_endpoints(app, api_dependency=api_dependency)
+                    await create_dynamic_endpoints(
+                        app,
+                        api_dependency=api_dependency,
+                        tools_timeout=tools_timeout,
+                        tools_interval=tools_interval,
+                    )
                     yield
 
 
@@ -134,6 +155,10 @@ async def run(
 
     # MCP Config
     config_path = kwargs.get("config_path")
+
+    # MCP Tool
+    tools_timeout = kwargs.get("tools_timeout", 15)
+    tools_interval = kwargs.get("tools_interval", 1)
 
     # mcpo server
     name = kwargs.get("name") or "MCP OpenAPI Proxy"
@@ -161,6 +186,8 @@ async def run(
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    main_app.state.tools_timeout = tools_timeout
+    main_app.state.tools_interval = tools_interval
 
     # Add middleware to protect also documentation and spec
     if api_key and strict_auth:
@@ -202,6 +229,8 @@ async def run(
                 allow_methods=["*"],
                 allow_headers=["*"],
             )
+            sub_app.state.tools_timeout = tools_timeout
+            sub_app.state.tools_interval = tools_interval
 
             if server_cfg.get("command"):
                 # stdio

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Dict, ForwardRef, List, Optional, Type, Union
 
@@ -25,6 +26,25 @@ MCP_ERROR_TO_HTTP_STATUS = {
     INVALID_PARAMS: 422,
     INTERNAL_ERROR: 500,
 }
+
+
+async def wait_list_tools(session, timeout: int = 15, interval: int = 1) -> list:
+    """
+    Polls the MCP server until the tool list is available or timeout is reached.
+    Raises TimeoutError if tools are not available within the timeout.
+    """
+    start = asyncio.get_event_loop().time()
+    last_error = None
+    while True:
+        try:
+            tools_result = await session.list_tools()
+            if getattr(tools_result, "tools", None):
+                return tools_result
+        except Exception as e:
+            last_error = e
+        if asyncio.get_event_loop().time() - start > timeout:
+            raise TimeoutError(f"Timed out waiting for MCP server tools: {last_error}")
+        await asyncio.sleep(interval)
 
 
 def process_tool_response(result: CallToolResult) -> list:


### PR DESCRIPTION

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Adds configurable `tools_timeout` and `tools_interval` parameters to ensure the client waits for the MCP server to be fully ready before listing tools. This prevents issues where the **tool list** is empty if the server is not ready, which can break API docs and OpenWebUI integration.

I believe that every MCP server should provide tools—otherwise, there would be no point in building it. However, at the current stage, during the MCP connection process, some servers (when started via `session.initialize`) do not return any results from `list_tools` (instead, it returns an empty list []). It is **necessary to wait for a while** before calling `list_tools` to get the correct results.

Based on my testing with an MCP server developed using `mcpsharp` (please forgive me for not being able to share the code due to security concerns), starting the MCP server takes some time. When I added print(tools) to the source code, I observed the following output:

```
Starting MCP OpenAPI Proxy on 0.0.0.0:8000 with command: cmd.exe /c C:\example.exe
INFO:     Started server process 36m43812
INFO:     Waiting for application startup.
TEST PRINT: Tools:  []
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
```

Since the tools have not yet been loaded, the API documentation (`localhost:8000/docs`) appears empty (at this point, OpenWebUI will hang), as shown below:

![image](https://github.com/user-attachments/assets/5a027e8e-24c5-4888-bdd5-f7c302001873)

### Added

- `tools_timeout` and `tools_interval` parameters, configurable via CLI or config, passed through app state.
- Polling mechanism in `wait_list_tools` to wait for tools to be available.

### Changed

### Deprecated


### Removed

### Fixed

- Fixes issue where tools list could be empty if the server is not fully started.

### Security


### Breaking Changes

---

### Additional Information

### Screenshots or Videos
