### PR TITLE
feat: Add create_app function

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -117,13 +117,11 @@ async def lifespan(app: FastAPI):
                     yield
 
 
-async def run(
-    host: str = "127.0.0.1",
-    port: int = 8000,
+def create_app(
     api_key: Optional[str] = "",
     cors_allow_origins=["*"],
     **kwargs,
-):
+) -> FastAPI:
     # Server API Key
     api_dependency = get_verify_api_key(api_key) if api_key else None
     strict_auth = kwargs.get("strict_auth", False)
@@ -224,6 +222,18 @@ async def run(
     else:
         raise ValueError("You must provide either server_command or config.")
 
+    return main_app
+
+async def run(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    api_key: Optional[str] = "",
+    cors_allow_origins=["*"],
+    **kwargs,
+):
+    main_app = create_app(api_key=api_key, cors_allow_origins=cors_allow_origins, **kwargs)
+    ssl_certfile = kwargs.get("ssl_certfile")
+    ssl_keyfile = kwargs.get("ssl_keyfile")
     config = uvicorn.Config(
         app=main_app,
         host=host,


### PR DESCRIPTION
# Changelog Entry

## Description

This change refactors the FastAPI application construction logic out of the `run` function in `mcpo/main.py` into a new public function, `create_app`. The new `create_app` function encapsulates all logic for building and configuring the main FastAPI app and any sub-apps, making the codebase more modular, testable, and reusable. The `run` function now simply calls `create_app` to obtain the app instance and passes it to Uvicorn for serving.

## Added
- `create_app` function

Moved the code that creates the FastAPI instance to its own function so that it may be used elsewhere outside the context of MCPO.

## Additional Information

I would like to utilize the proxy functionality in my own monolith application, being able to just return the FastAPI will allow me to mount it to my own FastAPI parent app.
