### PR TITLE
Fix: Enable environment variable inheritance for Smithery cloud services authentication

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -103,7 +103,7 @@ async def lifespan(app: FastAPI):
             server_params = StdioServerParameters(
                 command=command,
                 args=args,
-                env={**env},
+                env={**os.environ, **env},
             )
 
             async with stdio_client(server_params) as (reader, writer):


### PR DESCRIPTION
## 🔧 Fixes Issue with Smithery Cloud Services Authentication

**Resolves:** Authentication failures causing 500 Internal Server Errors when using Smithery cloud services through MCPO (related to Discussion #101)

## 🚨 Problem
MCPO was not passing environment variables to Smithery CLI subprocesses, causing authentication failures with cloud services like:
- Context7 (library search & documentation)
- Office Word (document automation) 
- Playwright (browser automation)

**Error:** `{"detail": {"message": "Unexpected error", "error": ""}}`

## ✅ Solution
Modified `StdioServerParameters` to inherit parent environment variables:
```python
# Before
env={**env},

# After  
env={**os.environ, **env},