### PR TITLE
Gracefully shutdown uvicorn.Server on task cancellation in run()

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import logging
 import socket
+import asyncio
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Optional
 
@@ -341,4 +342,9 @@ async def run(
     )
     server = uvicorn.Server(config)
 
-    await server.serve()
+    try:
+        await server.serve()
+    except asyncio.CancelledError:
+        server.should_exit = True
+        await server.shutdown()
+        raise 


### PR DESCRIPTION
### Summary

This PR updates the `run()` function to properly shut down the `uvicorn.Server` when the task is cancelled via `task.cancel()`.

### Motivation

Previously, cancelling the task running `run()` did not stop the `uvicorn` server, leaving the socket bound to the port and causing issues when trying to restart or cleanly terminate the server. This change handles `asyncio.CancelledError` and triggers `server.should_exit = True` and `await server.shutdown()` to release resources.

### Changes

- Added `try/except asyncio.CancelledError` block around `server.serve()`
- On cancellation, `server.should_exit` is set and `server.shutdown()` is awaited before re-raising the cancellation

### Testing

Tested locally by launching `run()` via `asyncio.create_task()` and then cancelling it. Confirmed that the uvicorn server exits cleanly and releases the port.
