### PR TITLE
Fix: Handle MCP parameter names with 2 leading underscores

### DIFF
--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -226,10 +226,8 @@ def get_model_fields(form_model_name, properties, required_fields, schema_defs=N
 
         # Handle parameter names with leading underscores (e.g., __top, __filter) which Pydantic v2 does not allow
         if name_needs_alias(param_name):
-            print(f"DEBUG: Handling underscore parameter: {param_name}")
             other_names = set().union(properties, model_fields, _model_cache)
             alias_name = generate_alias_name(param_name, other_names)
-            print(f"DEBUG: Clean name for {param_name} is {alias_name}")
             aliased_field = Field(
                 default=pydantic_field_info.default,
                 description=pydantic_field_info.description,


### PR DESCRIPTION
Add field aliasing for parameters starting with '__' (e.g., __top, __filter) - Apply fix to both top-level and nested object properties - Use by_alias=True in model_dump to preserve original parameter names for MCP calls - Prevents Pydantic v2 NameError. Enables compatibility with  OData-based APIs.

Fixes feat #160 (IMO addressing incompatibility with some MCP interfaces is a bug fix, not a new feature)

# Changelog Entry

### Description
Fixes Pydantic v2 validation error when MCP servers use parameter names with leading underscores (e.g., `__top`, `__filter`) (e.g. any OData-based APIs that follow Microsoft Graph API conventions).

### Added
- Field aliasing for parameters with leading underscores in Pydantic model generation
- Support for both top-level and nested object properties with leading underscore names

### Fixed
- Pydantic v2 NameError: "Fields must not use names with leading underscores"