### PR TITLE
fix: return to break loop of $ref in schema, avoid some case of Custo…

### DIFF
--- a/src/mcpo/tests/test_main.py
+++ b/src/mcpo/tests/test_main.py
@@ -310,3 +310,18 @@ def test_multi_type_property_with_any_of():
 
     # assert result_field parameter config
     assert result_field.description == "A property with multiple types"
+
+
+def test_ref_to_parent_node():
+    schema = {'$ref': '#/properties/data/properties/children/items'}
+    result_type, result_field = _process_schema_property(
+        _model_cache,
+        schema,
+        "generate_fishbone_diagram_form_model_data_model_children_item_model_children",
+        "item",
+        False,
+        {}
+    )
+
+    assert result_type == Any
+    assert result_field.description == ""

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -93,6 +93,19 @@ def _process_schema_property(
     """
     if "$ref" in prop_schema:
         ref = prop_schema["$ref"]
+        if ref.startswith("#/properties/"):
+            # Remove common prefix in pathes.
+            prefix_path = model_name_prefix.split("_form_model_")[-1]
+            ref_path = ref.split("#/properties/")[-1]
+            # Translate $ref path to model_name_prefix style.
+            ref_path = ref_path.replace("/properties/", "_model_")
+            ref_path = ref_path.replace("/items", "_item")
+            # If $ref path is a prefix substring of model_name_prefix path,
+            # there exists a circular reference.
+            # The loop should be broke with a return to avoid exception.
+            if prefix_path.startswith(ref_path):
+                # TODO: Find the exact type hint for the $ref.
+                return Any, Field(default=None, description="")
         ref = ref.split("/")[-1]
         assert ref in schema_defs, "Custom field not found"
         prop_schema = schema_defs[ref]


### PR DESCRIPTION
…m-field-not-found exception.

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- When schema of tool has a $ref points to its parant node, it makes a circular reference and will cause a "Custom field not found" exception in function _process_schema_property(). 
- `return Any, Field(default=None, description="")` in these cases to avoid exception.
- I made the fix an atomic and pure incremental patch so it can't get worse than before.


### Changed

- `return Any, Field(default=None, description="")` in function _process_schema_property() when schema of tool has a $ref points to its parant node.

### Fixed

- Circular reference caused "Custom field not found" exceptions

---

# Additional Information

### Bug Scene

Schema from [mcp-server-chart](https://github.com/antvis/mcp-server-chart) for example:
```json
{
  "name": "generate_fishbone_diagram",
  "description": "Generate a fishbone diagram chart to uses a fish skeleton, like structure to display the causes or effects of a core problem, with the problem as the fish head and the causes/effects as the fish bones. It suits problems that can be split into multiple related factors.",
  "inputSchema": {
    "$schema": "http://json-schema.org/draft-07/schema#",
    "type": "object",
    "properties": {
      "data": {
        "type": "object",
        "properties": {
          "name": { "type": "string" },
          "children": {
            "type": "array",
            "items": {
              "properties": {
                "name": { "type": "string" },
                "children": {
                  "type": "array",
                  "items": {
                    "$ref": "#/properties/data/properties/children/items"
                  }
                }
              },
              "required": ["name"],
              "type": "object"
            }
          }
        },
        "required": ["name"],
        "description": "Data for fishbone diagram chart, such as, { name: 'main topic', children: [{ name: 'topic 1', children: [{ name: 'subtopic 1-1' }] }."
      },
      "theme": {
        "default": "default",
        "description": "Set the theme for the chart, optional, default is 'default'.",
        "enum": ["default", "academy"],
        "type": "string"
      },
      "width": {
        "type": "number",
        "description": "Set the width of chart, default is 600.",
        "default": 600
      },
      "height": {
        "type": "number",
        "description": "Set the height of chart, default is 400.",
        "default": 400
      }
    },
    "required": ["data"]
  }
}
```

### Testing

- Unittest case added and passed. Just do `pytest` in the project to check.
- We can start [mcp-server-chart](https://github.com/antvis/mcp-server-chart) with mcpo now:
![截图 2025-06-07 10-45-19](https://github.com/user-attachments/assets/8fcf6131-9871-4898-bb16-cc90732d7028)
- [mcp-server-chart](https://github.com/antvis/mcp-server-chart) tools work with the fix in open-webui confirmed.