### PR TITLE
fix(server_type): SSE server does not reconnect if session lost

### DIFF
--- a/src/mcpo/tests/test_sse.py
+++ b/src/mcpo/tests/test_sse.py
@@ -1,0 +1,34 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from mcpo.utils.sse import sse_client_loop
+from fastapi import FastAPI
+
+@pytest.mark.asyncio
+async def test_sse_client_loop():
+    # Mock dependencies
+    app = FastAPI()
+    api_dependency = MagicMock()
+    create_dynamic_endpoints = AsyncMock()
+    
+    # Mock the sse_client context manager
+    mock_reader = AsyncMock()
+    mock_writer = AsyncMock()
+    mock_session = AsyncMock()
+    
+    # Set up the mock reader to return a message once and then raise a CancelledError
+    mock_reader.receive.side_effect = [MagicMock(), asyncio.CancelledError()]
+
+    with patch('mcpo.utils.sse.sse_client') as mock_sse_client, \
+         patch('mcpo.utils.sse.ClientSession') as mock_client_session:
+        
+        mock_sse_client.return_value.__aenter__.return_value = (mock_reader, mock_writer)
+        mock_client_session.return_value.__aenter__.return_value = mock_session
+
+        # Run the sse_client_loop
+        await sse_client_loop("http://test-url", {}, api_dependency, create_dynamic_endpoints, app)
+
+    # Verify that the functions were called as expected
+    create_dynamic_endpoints.assert_awaited_once_with(app, api_dependency=api_dependency)
+    mock_reader.receive.assert_awaited()
+    assert mock_reader.receive.await_count == 2  # Once for the message, once for the CancelledError

--- a/src/mcpo/utils/sse.py
+++ b/src/mcpo/utils/sse.py
@@ -1,0 +1,35 @@
+import asyncio
+import logging
+import traceback
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+logger = logging.getLogger(__name__)
+
+async def sse_client_loop(url, headers, api_dependency, create_dynamic_endpoints, app):
+    while True:
+        try:
+            async with sse_client(
+                url=url, sse_read_timeout=None, headers=headers
+            ) as (reader, writer):
+                async with ClientSession(reader, writer) as session:
+                    app.state.session = session
+                    await create_dynamic_endpoints(app, api_dependency=api_dependency)
+                    while True:
+                        try:
+                            msg = await asyncio.wait_for(reader.receive(), timeout=60)
+                            if isinstance(msg, Exception):
+                                raise msg
+                        except asyncio.TimeoutError:
+                            logger.warning("SSE read timeout, reconnecting...")
+                            break
+        except asyncio.CancelledError:
+            logger.info("SSE client connection cancelled, shutting down...")
+            return
+        except Exception as e:
+            if isinstance(e, ExceptionGroup):
+                root_cause = e.exceptions[0]
+                logger.error(f"SSE client error: {type(root_cause).__name__}: {root_cause}")
+            else:
+                logger.error(f"SSE client error: {e}")
+            await asyncio.sleep(5)  # Wait before reconnecting


### PR DESCRIPTION
# Changelog Entry

## [0.0.16] - 2025-06-19

### Fixed

- 🔄 **SSE Server Reconnection**: Fixed an issue where the SSE server would not reconnect if the session was lost. This improves the stability and reliability of SSE-based MCP connections.


### Description

- Currently if you start an SSE server and the SSE sessions is lost, `mcpo` does not try to re-establish the connection, resulting in any subsequent calls to fail due to `asnycio.ClosedResourceError`. 
- The `reader` from `sse_client` is never called so any errors after the client has connected never get handled. 
- This PR calls `sse_client` in a loop as a background task allowing it to attempt to reconnect as long as the `mcpo` server is active 