### PR TITLE
enh: Allow for startup if some MCPs unavailable, graceful shutdown and better subtask handling

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -89,7 +89,7 @@ async def lifespan(app: FastAPI):
     command = getattr(app.state, "command", None)
     args = getattr(app.state, "args", [])
     env = getattr(app.state, "env", {})
-    connection_timeout = getattr(app.state, "connection_timeout", 10)
+    connection_timeout = getattr(app.state, "connection_timeout", 5)
     api_dependency = getattr(app.state, "api_dependency", None)
 
     # This is the main app's lifespan, it orchestrates sub-apps

--- a/uv.lock
+++ b/uv.lock
@@ -313,7 +313,7 @@ cli = [
 
 [[package]]
 name = "mcpo"
-version = "0.0.14"
+version = "0.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
@tjbck this closes:
https://github.com/open-webui/mcpo/issues/193
and several others 

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **refactor**: Code restructuring for better maintainability, readability, or scalability

# Changelog Entry

### Description

- This pull request refactors the server lifecycle management to introduce robust graceful shutdown capabilities and a more resilient, concurrent startup process. These changes improve server stability, provide better diagnostic logging, and ensure cleaner resource management upon termination.

### Added

- [`GracefulShutdown`](src/mcpo/main.py:18) class to handle `SIGINT` and `SIGTERM` signals, ensuring all server tasks are properly cancelled and awaited.
- Concurrent initialization of MCP servers during startup using `asyncio.gather` in the main app [`lifespan`](src/mcpo/main.py:102) for faster launch times.
- A detailed startup summary is now logged to the console, clearly listing successfully connected and failed MCP servers.
- Explicit connection status tracking (`app.state.is_connected`) for sub-applications to reliably determine connectivity.

### Changed

- The application [`lifespan`](src/mcpo/main.py:102) logic was significantly refactored to support concurrent startup and provide clearer connection status reporting.
- The main [`run`](src/mcpo/main.py:155) function now integrates the `GracefulShutdown` handler to manage the server lifecycle.
- The main application's description is now dynamically updated to include documentation links for only the servers that connected successfully.
- Updated `mcpo` package version from `0.0.14` to `0.0.16` in [`uv.lock`](uv.lock:317).

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- This refactor improves the overall robustness of the MCP server host. By handling system signals gracefully, it prevents orphaned processes and ensures a clean shutdown. The concurrent startup and improved logging make the system easier to manage and debug, especially in environments with multiple configured MCP servers.

### Screenshots or Videos

- N/A