### PR TITLE
fix: pass schema def

### DIFF
--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -129,6 +129,7 @@ def _process_schema_property(
                 f"{model_name_prefix}_{prop_name}",
                 f"choice_{i}",
                 False,
+                schema_defs=schema_defs,
             )
             type_hints.append(type_hint)
         return Union[tuple(type_hints)], pydantic_field

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -143,7 +143,12 @@ def _process_schema_property(
             temp_schema = dict(prop_schema)
             temp_schema["type"] = type_option
             type_hint, _ = _process_schema_property(
-                _model_cache, temp_schema, model_name_prefix, prop_name, False
+                _model_cache,
+                temp_schema,
+                model_name_prefix,
+                prop_name,
+                False,
+                schema_defs=schema_defs,
             )
             type_hints.append(type_hint)
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [ ] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [ ] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [ ] **Testing:** Have you written and run sufficient tests to validate the changes?
- [ ] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

Fixed an issue where `schema_defs` was not being passed when `_process_schema_property` was called recursively. This caused errors due to missing `schema_defs` in those recursive calls.

```python
      |   File "/Users/***/git/python/repo/***/.venv/lib/python3.13/site-packages/mcpo/utils/main.py", line 126, in _process_schema_property
      |     type_hint, _ = _process_schema_property(
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~^
      |         _model_cache,
      |         ^^^^^^^^^^^^^
      |     ...<3 lines>...
      |         False,
      |         ^^^^^^
      |     )
      |     ^
      |   File "/Users/***/git/python/repo/***/.venv/lib/python3.13/site-packages/mcpo/utils/main.py", line 204, in _process_schema_property
      |     item_type_hint, _ = _process_schema_property(
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~^
      |         _model_cache,
      |         ^^^^^^^^^^^^^
      |     ...<4 lines>...
      |         schema_defs,
      |         ^^^^^^^^^^^^
      |     )
      |     ^
      |   File "/Users/***/git/python/repo/***/.venv/lib/python3.13/site-packages/mcpo/utils/main.py", line 112, in _process_schema_property
      |     assert ref in schema_defs, "Custom field not found"
      |            ^^^^^^^^^^^^^^^^^^
      | TypeError: argument of type 'NoneType' is not iterable
      +------------------------------------
```

### Fixed

When calling `_process_schema_property` recursively, the `schema_defs` argument was not being passed. This caused the following assertion to fail:

```python
    if "$ref" in prop_schema:
        ref = prop_schema["$ref"]
        if ref.startswith("#/properties/"):
            # Remove common prefix in pathes.
            prefix_path = model_name_prefix.split("_form_model_")[-1]
            ref_path = ref.split("#/properties/")[-1]
            # Translate $ref path to model_name_prefix style.
            ref_path = ref_path.replace("/properties/", "_model_")
            ref_path = ref_path.replace("/items", "_item")
            # If $ref path is a prefix substring of model_name_prefix path,
            # there exists a circular reference.
            # The loop should be broke with a return to avoid exception.
            if prefix_path.startswith(ref_path):
                # TODO: Find the exact type hint for the $ref.
                return Any, Field(default=None, description="")
        ref = ref.split("/")[-1]
        assert ref in schema_defs, "Custom field not found"
        prop_schema = schema_defs[ref]
```

---
