### PR TITLE
Feat: Tools can be filtered out using the `disabledTools` configuration option in the server declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog,
 and this project adheres to Semantic Versioning.
 
+## [0.0.18] - 2025-09-07
+
+### Added
+
+- 🔧 **Support for disabling specific tools**: Tools can be filtered out using the `disabledTools` configuration option in the server declaration.
+
 ## [0.0.17] - 2025-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Example config.json:
     },
     "time": {
       "command": "uvx",
-      "args": ["mcp-server-time", "--local-timezone=America/New_York"]
+      "args": ["mcp-server-time", "--local-timezone=America/New_York"],
+      "disabledTools": ["convert_time"] // Disable specific tools if needed
     },
     "mcp_sse": {
       "type": "sse", // Explicitly define type

--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -68,6 +68,15 @@ def validate_server_config(server_name: str, server_cfg: Dict[str, Any]) -> None
         pass
     else:
         raise ValueError(f"Server '{server_name}' must have either 'command' for stdio or 'type' and 'url' for remote servers")
+    
+    # Validate disabledTools
+    disabled_tools = server_cfg.get("disabledTools")
+    if disabled_tools is not None:
+        if not isinstance(disabled_tools, list):
+            raise ValueError(f"Server '{server_name}' 'disabledTools' must be a list")
+        for tool_name in disabled_tools:
+            if not isinstance(tool_name, str):
+                raise ValueError(f"Server '{server_name}' 'disabledTools' must contain only strings")
 
 
 def load_config(config_path: str) -> Dict[str, Any]:
@@ -146,6 +155,7 @@ def create_sub_app(server_name: str, server_cfg: Dict[str, Any], cors_allow_orig
 
     sub_app.state.api_dependency = api_dependency
     sub_app.state.connection_timeout = connection_timeout
+    sub_app.state.disabled_tools = server_cfg.get("disabledTools", [])
 
     return sub_app
 
@@ -270,6 +280,15 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
 
     tools_result = await session.list_tools()
     tools = tools_result.tools
+    
+    # Filter out disabled tools
+    disabled_tools = getattr(app.state, "disabled_tools", [])
+    if disabled_tools:
+        original_count = len(tools)
+        tools = [tool for tool in tools if tool.name not in disabled_tools]
+        filtered_count = original_count - len(tools)
+        if filtered_count > 0:
+            logger.info(f"Filtered out {filtered_count} tool(s) for server '{app.title}': {disabled_tools}")
 
     for tool in tools:
         endpoint_name = tool.name

--- a/src/mcpo/tests/test_hot_reload.py
+++ b/src/mcpo/tests/test_hot_reload.py
@@ -42,6 +42,19 @@ def test_validate_server_config_missing_url():
         validate_server_config("test_server", config)
 
 
+def test_validate_server_config_disabled_tools_valid():
+    """Test validation of server configuration with a valid disabledTools."""
+    config = {"command": "echo", "args": ["hello"], "disabledTools": ["search-web"]}
+    validate_server_config("test_server", config)
+
+
+def test_validate_server_config_disabled_tools_invalid():
+    """Test validation fails for an invalid disabledTools."""
+    config = {"command": "echo", "args": ["hello"], "disabledTools": "not-a-list"}
+    with pytest.raises(ValueError, match="'disabledTools' must be a list"):
+        validate_server_config("test_server", config)
+
+
 def test_load_config_valid():
     """Test loading a valid config file."""
     config_data = {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [*] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [*] **Description:** Provide a concise description of the changes made in this pull request.
- [*] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [*] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [*] **Testing:** Have you written and run sufficient tests to validate the changes?
- [*] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [*] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- Added a feature for disabling individual options from a server.
- Motivation: dealing with complex servers, sometimes it is desirable to avoid declaring all the features to the model. For example, a MCP server that has both "read" and "write" capabilities, can be important to disable the "write" capabilities.
- The parameter is based on how Roo code does it.

### Added

- Created a new configuration option `disabledTools` in the server declaration, to indicate tools that must be filtered out from the model.

### Changed

- main.py - added a new validation for the new option in the `mcp.config.json` file:

```
    # Validate disabledTools
    disabled_tools = server_cfg.get("disabledTools")
    if disabled_tools is not None:
        if not isinstance(disabled_tools, list):
            raise ValueError(f"Server '{server_name}' 'disabledTools' must be a list")
        for tool_name in disabled_tools:
            if not isinstance(tool_name, str):
                raise ValueError(f"Server '{server_name}' 'disabledTools' must contain only strings")
```
- main.py - added a new filter to remove tools that are listed in the `disabledTools` option in the `mcp.config.json` file:
```
    # Filter out disabled tools
    disabled_tools = getattr(app.state, "disabled_tools", [])
    if disabled_tools:
        original_count = len(tools)
        tools = [tool for tool in tools if tool.name not in disabled_tools]
        filtered_count = original_count - len(tools)
        if filtered_count > 0:
            logger.info(f"Filtered out {filtered_count} tool(s) for server '{app.title}': {disabled_tools}")
```
- test_hot_reload.py -  added two new tests:

`test_validate_server_config_disabled_tools_valid():`
`test_validate_server_config_disabled_tools_invalid():`

---

### Additional Information

- [Insert any additional context, notes, or explanations for the changes]
  - [Reference any related issues, commits, or other relevant information]

### Screenshots or Videos

- [Attach any relevant screenshots or videos demonstrating the changes]
