### PR TITLE
fix: Initialize and track lifespans for sub-apps made during hot reload

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -167,17 +167,21 @@ def mount_config_servers(main_app: FastAPI, config_data: Dict[str, Any],
 
 def unmount_servers(main_app: FastAPI, path_prefix: str, server_names: list):
     """Unmount specific MCP servers."""
+    active_lifespans = getattr(main_app.state, 'active_lifespans', {})
+    
     for server_name in server_names:
         mount_path = f"{path_prefix}{server_name}"
-        # Find and remove the mount
-        routes_to_remove = []
-        for route in main_app.router.routes:
-            if hasattr(route, 'path') and route.path == mount_path:
-                routes_to_remove.append(route)
-
-        for route in routes_to_remove:
-            main_app.router.routes.remove(route)
-            logger.info(f"Unmounted server: {server_name}")
+        
+        # Clean up lifespan context if it exists
+        if server_name in active_lifespans:
+            lifespan_context = active_lifespans[server_name]
+            try:
+                # Schedule cleanup of the lifespan context
+                asyncio.create_task(lifespan_context.__aexit__(None, None, None))
+            except Exception as e:
+                logger.warning(f"Error cleaning up lifespan for {server_name}: {e}")
+            finally:
+                del active_lifespans[server_name]
 
 
 async def reload_config_handler(main_app: FastAPI, new_config_data: Dict[str, Any]):
@@ -225,6 +229,11 @@ async def reload_config_handler(main_app: FastAPI, new_config_data: Dict[str, An
         # Add new servers and updated servers
         if servers_to_add:
             logger.info(f"Adding servers: {list(servers_to_add)}")
+
+            # Store lifespan contexts for cleanup
+            if not hasattr(main_app.state, 'active_lifespans'):
+                main_app.state.active_lifespans = {}
+            
             for server_name in servers_to_add:
                 server_cfg = new_config_data["mcpServers"][server_name]
                 try:
@@ -233,6 +242,21 @@ async def reload_config_handler(main_app: FastAPI, new_config_data: Dict[str, An
                         strict_auth, api_dependency, connection_timeout, lifespan
                     )
                     main_app.mount(f"{path_prefix}{server_name}", sub_app)
+                                        
+                    # Start the lifespan for the new sub-app
+                    lifespan_context = sub_app.router.lifespan_context(sub_app)
+                    await lifespan_context.__aenter__()
+                    
+                    # Store the context manager for cleanup later
+                    main_app.state.active_lifespans[server_name] = lifespan_context
+                    
+                    # Check if connection was successful
+                    is_connected = getattr(sub_app.state, "is_connected", False)
+                    if is_connected:
+                        logger.info(f"Successfully connected to new server: '{server_name}'")
+                    else:
+                        logger.warning(f"Failed to connect to new server: '{server_name}'")
+                        
                 except Exception as e:
                     logger.error(f"Failed to create server '{server_name}': {e}")
                     # Rollback on failure


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [~] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

- When using hot reload functionality, tooling fails to populate as the lifespan handler is not entered.

### Added

- None

### Changed

- None

### Deprecated

- None

### Removed

- None

### Fixed

- Fixed lifespan execution when hot reloading adding servers

### Security

- None

### Breaking Changes

- None

---

### Additional Information

- To replicate the bug, I used SSE MCP servers and modified a header. When hot reloading, the functionality is to remove and re-add, however the lifespan() function does not fire at this time for the sub-app (only on initial load).
