### PR TITLE
Fix: the disabled_tools feature is always rising an exception on execution

### DIFF
--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -73,17 +73,14 @@ def validate_server_config(server_name: str, server_cfg: Dict[str, Any]) -> None
     else:
         raise ValueError(f"Server '{server_name}' must have either 'command' for stdio or 'type' and 'url' for remote servers")
     
-    # Validate disabledTools
+    # Validate disabled_tools
     disabled_tools = server_cfg.get("disabled_tools")
     if disabled_tools is not None:
         if not isinstance(disabled_tools, list):
-            raise ValueError(f"Server '{server_name}' 'disabledTools' must be a list")
+            raise ValueError(f"Server '{server_name}' 'disabled_tools' must be a list")
         for tool_name in disabled_tools:
             if not isinstance(tool_name, str):
-                raise ValueError(f"Server '{server_name}' 'disabledTools' must contain only strings")
-        raise ValueError(
-            f"Server '{server_name}' must have either 'command' for stdio or 'type' and 'url' for remote servers"
-        )
+                raise ValueError(f"Server '{server_name}' 'disabled_tools' must contain only strings")
 
 
 def load_config(config_path: str) -> Dict[str, Any]:


### PR DESCRIPTION
…meters were valid

Chore: consistency in the name of the feature: disabled_tools and not disabledTools

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [X] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [X] **Description:** Provide a concise description of the changes made in this pull request.
- [X] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [X] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [X] **Testing:** Have you written and run sufficient tests to validate the changes?
- [X] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [X] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **BREAKING CHANGE**: Significant changes that may affect compatibility
  - **build**: Changes that affect the build system or external dependencies
  - **ci**: Changes to our continuous integration processes or workflows
  - **chore**: Refactor, cleanup, or other non-functional code changes
  - **docs**: Documentation update or addition
  - **feat**: Introduces a new feature or enhancement to the codebase
  - **fix**: Bug fix or error correction
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvement
  - **refactor**: Code restructuring for better maintainability, readability, or scalability
  - **style**: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc.)
  - **test**: Adding missing tests or correcting existing tests
  - **WIP**: Work in progress, a temporary label for incomplete or ongoing work

# Changelog Entry

### Description

disabled_tools feature was not working. Looking at the original code:
```
    # Validate disabledTools
    disabled_tools = server_cfg.get("disabled_tools")
    if disabled_tools is not None:
        if not isinstance(disabled_tools, list):
            raise ValueError(f"Server '{server_name}' 'disabledTools' must be a list")
        for tool_name in disabled_tools:
            if not isinstance(tool_name, str):
                raise ValueError(f"Server '{server_name}' 'disabledTools' must contain only strings")
        raise ValueError(
            f"Server '{server_name}' must have either 'command' for stdio or 'type' and 'url' for remote servers"
        )
```
The `rise` at the end of the if block is **always** rising an exception if the validation is true, halting the code execution if the disabled_tools parameter is present and valid.

The fix: remove:
```
        raise ValueError(
            f"Server '{server_name}' must have either 'command' for stdio or 'type' and 'url' for remote servers"
        )
```

### Fixed
The disabled_tools feature is always rising an exception on execution

### Chore
Replacing disabledTools for disabled_tools in comments and console messages for consistency

---

### Screenshots or Videos

<img width="721" height="1035" alt="2025-12-18_10h12_47" src="https://github.com/user-attachments/assets/72128992-df3a-4852-8d55-b1a7dc44cf33" />



