### PR TITLE
fix: add enum support in OpenAPI schema generation

### DIFF
--- a/src/mcpo/tests/test_main.py
+++ b/src/mcpo/tests/test_main.py
@@ -1,6 +1,6 @@
 import pytest
 from pydantic import BaseModel, Field
-from typing import Any, List, Dict, Union
+from typing import Any, List, Dict, Literal, Union
 
 from mcpo.utils.main import _process_schema_property
 
@@ -306,7 +306,10 @@ def test_multi_type_property_with_any_of():
     assert len(result_type.__args__) == 3
     assert len(result_type.__args__[0].model_fields) == 2
     assert len(result_type.__args__[1].model_fields) == 1
-    assert result_type.__args__[2] is str
+    # Third type should be Literal['auto', 'none'] for enum strings
+    third_type = result_type.__args__[2]
+    assert hasattr(third_type, "__origin__") and third_type.__origin__ is Literal
+    assert set(third_type.__args__) == {"auto", "none"}
 
     # assert result_field parameter config
     assert result_field.description == "A property with multiple types"
@@ -325,3 +328,53 @@ def test_ref_to_parent_node():
 
     assert result_type == Any
     assert result_field.description == ""
+
+
+def test_process_string_enum():
+    """Test that string type with enum returns Literal type."""
+    schema = {
+        "type": "string",
+        "enum": ["read", "write", "admin"],
+        "description": "User permission level",
+    }
+    expected_field = Field(default=..., description="User permission level")
+    result_type, result_field = _process_schema_property(
+        _model_cache, schema, "test", "permission", True
+    )
+
+    assert hasattr(result_type, "__origin__") and result_type.__origin__ is Literal
+    assert set(result_type.__args__) == {"read", "write", "admin"}
+    assert result_field.default == expected_field.default
+    assert result_field.description == expected_field.description
+
+
+def test_process_integer_enum():
+    """Test that integer type with enum returns Literal type."""
+    schema = {
+        "type": "integer",
+        "enum": [1, 2, 3],
+        "description": "Priority level",
+    }
+    expected_field = Field(default=..., description="Priority level")
+    result_type, result_field = _process_schema_property(
+        _model_cache, schema, "test", "priority", True
+    )
+
+    assert hasattr(result_type, "__origin__") and result_type.__origin__ is Literal
+    assert set(result_type.__args__) == {1, 2, 3}
+    assert result_field.default == expected_field.default
+    assert result_field.description == expected_field.description
+
+
+def test_process_string_without_enum():
+    """Test that string type without enum still returns str."""
+    schema = {
+        "type": "string",
+        "description": "A simple string without enum",
+    }
+    result_type, result_field = _process_schema_property(
+        _model_cache, schema, "test", "name", True
+    )
+
+    assert result_type is str
+    assert result_field.description == "A simple string without enum"

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -1,7 +1,7 @@
 import logging
 import json
 import traceback
-from typing import Any, Dict, ForwardRef, List, Optional, Type, Union
+from typing import Any, Dict, ForwardRef, List, Literal, Optional, Type, Union
 
 from anyio import ClosedResourceError
 from fastapi import HTTPException, Request
@@ -230,8 +230,14 @@ def _process_schema_property(
         return list_type_hint, pydantic_field
 
     elif prop_type == "string":
+        enum_values = prop_schema.get("enum")
+        if enum_values:
+            return Literal[tuple(enum_values)], pydantic_field
         return str, pydantic_field
     elif prop_type == "integer":
+        enum_values = prop_schema.get("enum")
+        if enum_values:
+            return Literal[tuple(enum_values)], pydantic_field
         return int, pydantic_field
     elif prop_type == "boolean":
         return bool, pydantic_field


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

When MCP servers define enum constraints on string or integer properties, these constraints were not being reflected in the generated OpenAPI schema. This caused LLMs to guess field values incorrectly.

### Fixed

- Enum values in string type properties are now converted to `Literal[...values]` type
- Enum values in integer type properties are now converted to `Literal[...values]` type
- Updated existing tests to reflect the new enum handling behavior
- Added dedicated test cases for enum support

Closes #245