### PR TITLE
fix: handle $ref to properties in schema processing

### DIFF
--- a/src/mcpo/tests/test_main.py
+++ b/src/mcpo/tests/test_main.py
@@ -321,7 +321,81 @@ def test_ref_to_parent_node():
         "item",
         False,
         {},
+        root_properties=None,
     )
 
     assert result_type == Any
     assert result_field.description == ""
+
+
+def test_ref_to_sibling_property():
+    """Test $ref to sibling property in the same schema (Issue #117)."""
+    root_properties = {
+        "event_time_start": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Start time in ISO 8601 format",
+        },
+        "event_time_end": {
+            "$ref": "#/properties/event_time_start",
+            "description": "End time in ISO 8601 format",
+        },
+    }
+    schema = root_properties["event_time_end"]
+    result_type, result_field = _process_schema_property(
+        _model_cache,
+        schema,
+        "test_form_model",
+        "event_time_end",
+        False,
+        schema_defs={},
+        root_properties=root_properties,
+    )
+
+    assert result_type is str
+    # The merged description should be the one from the referencing schema
+    assert result_field.description == "End time in ISO 8601 format"
+
+
+def test_ref_to_defs():
+    """Test $ref to $defs works correctly."""
+    schema = {"$ref": "#/$defs/DateTimeField"}
+    schema_defs = {
+        "DateTimeField": {
+            "type": "string",
+            "format": "date-time",
+            "description": "A date-time field",
+        }
+    }
+    result_type, result_field = _process_schema_property(
+        _model_cache,
+        schema,
+        "test_form_model",
+        "created_at",
+        True,
+        schema_defs=schema_defs,
+        root_properties={},
+    )
+
+    assert result_type is str
+    assert result_field.description == "A date-time field"
+
+
+def test_ref_with_missing_target():
+    """Test $ref gracefully handles missing target."""
+    schema = {
+        "$ref": "#/properties/nonexistent",
+        "description": "Fallback description",
+    }
+    result_type, result_field = _process_schema_property(
+        _model_cache,
+        schema,
+        "test_form_model",
+        "field",
+        False,
+        schema_defs={},
+        root_properties={"other_field": {"type": "string"}},
+    )
+
+    assert result_type == Any
+    assert result_field.description == "Fallback description"

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -95,6 +95,7 @@ def _process_schema_property(
     prop_name: str,
     is_required: bool,
     schema_defs: Optional[Dict] = None,
+    root_properties: Optional[Dict] = None,
 ) -> tuple[Union[Type, List, ForwardRef, Any], FieldInfo]:
     """
     Recursively processes a schema property to determine its Python type hint
@@ -107,21 +108,53 @@ def _process_schema_property(
     if "$ref" in prop_schema:
         ref = prop_schema["$ref"]
         if ref.startswith("#/properties/"):
-            # Remove common prefix in pathes.
+            # Handle $ref to properties (e.g., "#/properties/event_time_start")
             prefix_path = model_name_prefix.split("_form_model_")[-1]
             ref_path = ref.split("#/properties/")[-1]
-            # Translate $ref path to model_name_prefix style.
-            ref_path = ref_path.replace("/properties/", "_model_")
-            ref_path = ref_path.replace("/items", "_item")
+            # Translate $ref path to model_name_prefix style for circular reference check
+            ref_path_normalized = ref_path.replace("/properties/", "_model_")
+            ref_path_normalized = ref_path_normalized.replace("/items", "_item")
             # If $ref path is a prefix substring of model_name_prefix path,
             # there exists a circular reference.
-            # The loop should be broke with a return to avoid exception.
-            if prefix_path.startswith(ref_path):
-                # TODO: Find the exact type hint for the $ref.
+            if prefix_path.startswith(ref_path_normalized):
                 return Any, Field(default=None, description="")
-        ref = ref.split("/")[-1]
-        assert ref in schema_defs, "Custom field not found"
-        prop_schema = schema_defs[ref]
+            # Resolve the reference from root_properties
+            if root_properties:
+                # Parse the path segments (e.g., "event_time_start" or "nested/properties/field")
+                path_segments = ref_path.split("/")
+                resolved_schema = root_properties
+                for segment in path_segments:
+                    if segment == "properties" and isinstance(resolved_schema, dict):
+                        resolved_schema = resolved_schema.get("properties", {})
+                    elif isinstance(resolved_schema, dict):
+                        resolved_schema = resolved_schema.get(segment)
+                    else:
+                        resolved_schema = None
+                        break
+                if resolved_schema and isinstance(resolved_schema, dict):
+                    # Merge any additional properties from the original prop_schema (like description)
+                    merged_schema = dict(resolved_schema)
+                    for key in prop_schema:
+                        if key != "$ref":
+                            merged_schema[key] = prop_schema[key]
+                    prop_schema = merged_schema
+                else:
+                    return Any, Field(default=None, description=prop_schema.get("description", ""))
+            else:
+                return Any, Field(default=None, description=prop_schema.get("description", ""))
+        elif ref.startswith("#/$defs/") or ref.startswith("#/definitions/"):
+            ref_name = ref.split("/")[-1]
+            if schema_defs and ref_name in schema_defs:
+                prop_schema = schema_defs[ref_name]
+            else:
+                return Any, Field(default=None, description=prop_schema.get("description", ""))
+        else:
+            # Handle other $ref formats (just take the last segment)
+            ref_name = ref.split("/")[-1]
+            if schema_defs and ref_name in schema_defs:
+                prop_schema = schema_defs[ref_name]
+            else:
+                return Any, Field(default=None, description=prop_schema.get("description", ""))
 
     prop_type = prop_schema.get("type")
     prop_desc = prop_schema.get("description", "")
@@ -141,6 +174,7 @@ def _process_schema_property(
                 f"choice_{i}",
                 False,
                 schema_defs=schema_defs,
+                root_properties=root_properties,
             )
             type_hints.append(type_hint)
         return Union[tuple(type_hints)], pydantic_field
@@ -160,6 +194,7 @@ def _process_schema_property(
                 prop_name,
                 False,
                 schema_defs=schema_defs,
+                root_properties=root_properties,
             )
             type_hints.append(type_hint)
 
@@ -187,6 +222,7 @@ def _process_schema_property(
                 name,
                 is_nested_required,
                 schema_defs,
+                root_properties=root_properties,
             )
 
             if name_needs_alias(name):
@@ -225,6 +261,7 @@ def _process_schema_property(
             "item",
             False,  # Items aren't required at this level,
             schema_defs,
+            root_properties=root_properties,
         )
         list_type_hint = List[item_type_hint]
         return list_type_hint, pydantic_field
@@ -257,6 +294,7 @@ def get_model_fields(form_model_name, properties, required_fields, schema_defs=N
             param_name,
             is_required,
             schema_defs,
+            root_properties=properties,
         )
 
         # Handle parameter names with leading underscores (e.g., __top, __filter) which Pydantic v2 does not allow


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Target branch:** Please verify that the pull request targets the `dev` branch.
- [x] **Description:** Provide a concise description of the changes made in this pull request.
- [x] **Changelog:** Ensure a changelog entry following the format of [Keep a Changelog](https://keepachangelog.com/) is added at the bottom of the PR description.
- [x] **Dependencies:** Are there any new dependencies? Have you updated the dependency versions in the documentation?
- [x] **Testing:** Have you written and run sufficient tests to validate the changes?
- [x] **Code review:** Have you performed a self-review of your code, addressing any coding standard issues and ensuring adherence to the project's coding standards?
- [x] **Prefix:** To clearly categorize this pull request, prefix the pull request title using one of the following:
  - **fix**: Bug fix or error correction

# Changelog Entry

### Description

When MCP servers use intra-schema property references like `{"$ref": "#/properties/other_field"}`, mcpo would crash with `TypeError: argument of type 'NoneType' is not iterable` or `AssertionError: Custom field not found`. This PR fixes the schema reference resolution to properly handle references to properties.

### Fixed

- Add `root_properties` parameter to `_process_schema_property` to enable resolving `#/properties/` references
- Properly resolve `$ref` references that point to sibling properties in the same schema
- Handle `#/$defs/` and `#/definitions/` refs explicitly with proper error handling
- Gracefully handle missing ref targets by returning `Any` type instead of crashing
- Merge additional properties (like description) from referencing schema to resolved schema
- Added comprehensive tests for various `$ref` resolution scenarios

Closes #117