### PR TITLE
fix: handle list-valued JSON Schema array items (tuple validation)

### DIFF
--- a/src/mcpo/tests/test_main.py
+++ b/src/mcpo/tests/test_main.py
@@ -195,6 +195,67 @@ def test_process_array_of_objects():
     assert item_model_fields["item_id"].is_required()
 
 
+def test_process_array_with_tuple_items():
+    # JSON Schema tuple validation: "items" is a LIST of schemas.
+    # Previously crashed with "AttributeError: 'list' object has no attribute
+    # 'get'" (issue #296). Should now yield List[Union[str, int]].
+    schema = {"type": "array", "items": [{"type": "string"}, {"type": "integer"}]}
+    expected_field = Field(default=..., description="")
+    result_type, result_field = _process_schema_property(
+        _model_cache, schema, "test", "prop", True
+    )
+
+    assert str(result_type).startswith("typing.List[")
+    inner = result_type.__args__[0]  # the Union inside List[...]
+    assert inner.__origin__ == Union
+    assert str in inner.__args__
+    assert int in inner.__args__
+    assert result_field.default == expected_field.default
+
+
+def test_process_array_with_single_tuple_item():
+    # A one-element tuple-validation list should collapse to List[<type>].
+    schema = {"type": "array", "items": [{"type": "string"}]}
+    result_type, _ = _process_schema_property(
+        _model_cache, schema, "test", "prop", False
+    )
+    assert result_type == List[str]
+
+
+def test_process_array_with_empty_tuple_items():
+    # An empty tuple ("items": []) should fall back to List[Any] rather than
+    # crash (exercises the empty-element guard in the tuple branch).
+    schema = {"type": "array", "items": []}
+    result_type, _ = _process_schema_property(
+        _model_cache, schema, "test", "prop", False
+    )
+    assert result_type == List[Any]
+
+
+def test_process_array_with_prefix_items():
+    # Draft 2020-12 spells tuple validation as "prefixItems"; handle it the
+    # same way as a list-valued "items".
+    schema = {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}]}
+    result_type, _ = _process_schema_property(
+        _model_cache, schema, "test", "prop", True
+    )
+    assert str(result_type).startswith("typing.List[")
+    inner = result_type.__args__[0]
+    assert inner.__origin__ == Union
+    assert str in inner.__args__
+    assert int in inner.__args__
+
+
+def test_process_array_tuple_with_non_object_item():
+    # A tuple element that is a boolean sub-schema (or otherwise not an object)
+    # must not crash; it degrades to Any instead of raising.
+    schema = {"type": "array", "items": [True, {"type": "string"}]}
+    result_type, _ = _process_schema_property(
+        _model_cache, schema, "test", "prop", False
+    )
+    assert str(result_type).startswith("typing.List[")
+
+
 def test_process_empty_object():
     schema = {"type": "object", "properties": {}}
     expected_type = Dict[str, Any]  # Should default to Dict[str, Any] if no properties

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -213,11 +213,50 @@ def _process_schema_property(
 
     elif prop_type == "array":
         items_schema = prop_schema.get("items")
+
+        # JSON Schema "tuple validation" describes each position with its own
+        # schema. Draft-07 (and earlier) spells this as a list-valued "items";
+        # Draft 2020-12 renames it to "prefixItems". Either form would
+        # otherwise be passed into the recursive call below and crash on a
+        # `.get()` against a list (see issue #296). Collect the element schemas
+        # and represent the array as a list of their union.
+        prefix_items = prop_schema.get("prefixItems")
+        element_schemas = None
+        if isinstance(items_schema, list):
+            element_schemas = items_schema
+        elif isinstance(prefix_items, list):
+            element_schemas = list(prefix_items)
+            # In 2020-12 an object-valued "items" types the elements after the
+            # prefix tuple; fold it into the union too.
+            if isinstance(items_schema, dict):
+                element_schemas.append(items_schema)
+
+        if element_schemas is not None:
+            item_type_hints = []
+            for i, item_schema in enumerate(element_schemas):
+                if not isinstance(item_schema, dict):
+                    # boolean sub-schema (true/false) or other non-object form
+                    item_type_hints.append(Any)
+                    continue
+                item_type_hint, _ = _process_schema_property(
+                    _model_cache,
+                    item_schema,
+                    f"{model_name_prefix}_{prop_name}",
+                    f"item_{i}",
+                    False,  # Items aren't required at this level,
+                    schema_defs,
+                )
+                item_type_hints.append(item_type_hint)
+            if not item_type_hints:
+                # Empty tuple (e.g. "items": []) -> list of anything
+                return List[Any], pydantic_field
+            return List[Union[tuple(item_type_hints)]], pydantic_field
+
         if not items_schema:
-            # Default to list of anything if items schema is missing
+            # Missing/empty items schema -> list of anything
             return List[Any], pydantic_field
 
-        # Recursively determine the type of items in the array
+        # Single-schema "items": one schema for every element (unchanged path).
         item_type_hint, _ = _process_schema_property(
             _model_cache,
             items_schema,


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Target branch:** targets the `dev` branch.
- [x] **Description:** provided below.
- [x] **Changelog:** entry added below (Keep a Changelog format).
- [x] **Dependencies:** no new dependencies.
- [x] **Testing:** unit tests added and run — full suite passes (32 passed).
- [x] **Code review:** self-reviewed.
- [x] **Prefix:** title uses the `fix:` prefix.

# Changelog Entry

### Description

`_process_schema_property` assumed a property's `items` is always a single schema object. JSON Schema also allows `items` to be a list of schemas (tuple validation in Draft-07; Draft 2020-12 calls it `prefixItems`). When an MCP server emits that form, the list was passed into the recursive call and `prop_schema.get("type")` raised `AttributeError: 'list' object has no attribute 'get'`. Because this happens while building the route, the whole tool's endpoint failed to mount.

Reproduced with `@brave/brave-search-mcp-server` (#296). Minimal repro:

```python
_process_schema_property({}, {"type": "array",
    "items": [{"type": "string"}, {"type": "integer"}]}, "test", "prop", True)
# before: AttributeError: 'list' object has no attribute 'get'
# after:  typing.List[typing.Union[str, int]]
```

The fix handles list-valued `items` (and the 2020-12 `prefixItems` form) by building `List[Union[...]]` over the element schemas, mirroring how the function already handles `anyOf` and multi-type `type` lists. Non-object elements (e.g. boolean sub-schemas) and empty tuples fall back to `List[Any]` instead of crashing. This is a deliberate approximation — it does not model positional or fixed-length tuple semantics; the goal is to stop the mount-time crash and keep OpenAPI generation working. Happy to collapse it to a plain `List[Any]` if you'd prefer the smaller change.

### Added

- Regression tests in `src/mcpo/tests/test_main.py` for tuple-validation arrays: list `items`, `prefixItems`, single element, empty list, and a non-object (boolean) element.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- `AttributeError: 'list' object has no attribute 'get'` when a tool's input schema uses list-valued `items` / `prefixItems` (tuple validation), which previously stopped the tool's endpoint from mounting (#296).

### Security

- None.

### Breaking Changes

- None. The new code path only runs for tuple-style schemas; the existing single-object `items` path is unchanged.

---

### Additional Information

- Closes #296. The approach matches the `isinstance(items_schema, list)` guard suggested by the reporter in that issue.
- Scope: `src/mcpo/utils/main.py` (the `array` branch of `_process_schema_property`) plus tests in `src/mcpo/tests/test_main.py`. Behavior-preserving for all existing schemas.

### Screenshots or Videos

- N/A — logic fix; covered by unit tests (`pytest src/mcpo/tests/` → 32 passed).
