### PR TITLE
feat: support stdio cwd and document Xquik OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Example config.json:
   "mcpServers": {
     "memory": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"]
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "cwd": "/path/to/project"
     },
     "time": {
       "command": "uvx",
@@ -129,10 +130,26 @@ Example config.json:
     "mcp_streamable_http": {
       "type": "streamable-http",
       "url": "http://127.0.0.1:8002/mcp"
-    } // Streamable HTTP MCP Server
+    }, // Streamable HTTP MCP Server
+    "xquik": {
+      "type": "streamable-http",
+      "url": "https://xquik.com/mcp",
+      "oauth": {
+        "server_url": "https://xquik.com"
+      }
+    }
   }
 }
 ```
+
+The optional `cwd` field sets the child process directory for stdio servers.
+
+The Xquik entry uses OAuth 2.1 dynamic client registration. On first connection,
+mcpo opens the authorization flow and stores the resulting token. For headless
+API-key setup, follow the [Xquik MCP authentication guide](https://docs.xquik.com/mcp/overview)
+and keep credentials out of committed config files.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 Each tool will be accessible under its own unique route, e.g.:
 - http://localhost:8000/memory

--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -68,6 +68,7 @@ class MCPConnectionManager:
         env: Dict[str, str],
         headers: Optional[Dict[str, str]],
         connection_timeout: Optional[int],
+        cwd: Optional[str] = None,
         auth_provider: Optional[Any] = None,
     ):
         self.server_type = normalize_server_type(server_type)
@@ -76,6 +77,7 @@ class MCPConnectionManager:
         self.env = env
         self.headers = headers
         self.connection_timeout = connection_timeout
+        self.cwd = cwd
         self.auth_provider = auth_provider
 
         self._session: Optional[ClientSession] = None
@@ -168,6 +170,7 @@ class MCPConnectionManager:
                 command=self.command,
                 args=self.args,
                 env={**os.environ, **self.env},
+                cwd=self.cwd,
             )
             return stdio_client(server_params)
         if self.server_type == "sse":
@@ -201,6 +204,10 @@ def validate_server_config(server_name: str, server_cfg: Dict[str, Any]) -> None
             raise ValueError(f"Server '{server_name}' 'command' must be a string")
         if server_cfg.get("args") and not isinstance(server_cfg["args"], list):
             raise ValueError(f"Server '{server_name}' 'args' must be a list")
+        if "cwd" in server_cfg and (
+            not isinstance(server_cfg["cwd"], str) or not server_cfg["cwd"].strip()
+        ):
+            raise ValueError(f"Server '{server_name}' 'cwd' must be a non-empty string")
     elif server_cfg.get("url") and not server_type:
         # Fallback for old SSE config without explicit type
         pass
@@ -284,6 +291,7 @@ def create_sub_app(
         sub_app.state.command = server_cfg["command"]
         sub_app.state.args = server_cfg.get("args", [])
         sub_app.state.env = {**os.environ, **server_cfg.get("env", {})}
+        sub_app.state.cwd = server_cfg.get("cwd")
 
     server_config_type = server_cfg.get("type")
     if server_config_type == "sse" and server_cfg.get("url"):
@@ -578,6 +586,7 @@ async def lifespan(app: FastAPI):
     args = getattr(app.state, "args", [])
     args = args if isinstance(args, list) else [args]
     env = getattr(app.state, "env", {})
+    cwd = getattr(app.state, "cwd", None)
     connection_timeout = getattr(app.state, "connection_timeout", CONNECTION_TIMEOUT)
     api_dependency = getattr(app.state, "api_dependency", None)
     path_prefix = getattr(app.state, "path_prefix", "/")
@@ -710,6 +719,7 @@ async def lifespan(app: FastAPI):
                 env=env,
                 headers=headers,
                 connection_timeout=connection_timeout,
+                cwd=cwd,
                 auth_provider=auth_provider,
             )
             app.state.session_manager = session_manager

--- a/src/mcpo/tests/test_hot_reload.py
+++ b/src/mcpo/tests/test_hot_reload.py
@@ -1,12 +1,19 @@
-import os
 import json
+import os
 import tempfile
-import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
+
 import pytest
 from fastapi import FastAPI
 
-from mcpo.main import load_config, validate_server_config, reload_config_handler
+import mcpo.main as main_module
+from mcpo.main import (
+    MCPConnectionManager,
+    create_sub_app,
+    load_config,
+    reload_config_handler,
+    validate_server_config,
+)
 
 
 def test_validate_server_config_stdio():
@@ -14,6 +21,57 @@ def test_validate_server_config_stdio():
     config = {"command": "echo", "args": ["hello", "world"]}
     # Should not raise
     validate_server_config("test_server", config)
+
+
+def test_validate_server_config_stdio_cwd(tmp_path):
+    """Test validation and app state for a stdio working directory."""
+    cwd = str(tmp_path)
+    config = {"command": "python", "args": ["server.py"], "cwd": cwd}
+
+    validate_server_config("test_server", config)
+    app = create_sub_app(
+        "test_server",
+        config,
+        ["*"],
+        None,
+        False,
+        None,
+        None,
+        None,
+    )
+
+    assert app.state.cwd == cwd
+
+
+@pytest.mark.parametrize("cwd", [None, "", "   ", 7, []])
+def test_validate_server_config_invalid_cwd(cwd):
+    """Test validation fails for an invalid stdio working directory."""
+    with pytest.raises(ValueError, match="'cwd' must be a non-empty string"):
+        validate_server_config("test_server", {"command": "python", "cwd": cwd})
+
+
+def test_stdio_connection_forwards_cwd(monkeypatch, tmp_path):
+    """Test the configured working directory reaches the MCP SDK."""
+    captured = {}
+    context = object()
+
+    def capture_stdio_client(server_params):
+        captured["server_params"] = server_params
+        return context
+
+    monkeypatch.setattr(main_module, "stdio_client", capture_stdio_client)
+    manager = MCPConnectionManager(
+        server_type="stdio",
+        command="python",
+        args=["server.py"],
+        env={},
+        headers=None,
+        connection_timeout=None,
+        cwd=str(tmp_path),
+    )
+
+    assert manager._create_client_context() is context
+    assert captured["server_params"].cwd == str(tmp_path)
 
 
 def test_validate_server_config_sse():


### PR DESCRIPTION
## Summary
- Add `cwd` support for config-file stdio servers.
- Forward `cwd` through hot reload and reconnects into `StdioServerParameters`.
- Add an OAuth-first Xquik Streamable HTTP example.
- Remove the secret-bearing API-key placeholder from committed JSON.

Closes #288.

## Architecture and compatibility
- `cwd` stays optional and preserves existing config behavior.
- Validation rejects empty or non-string values early.
- Relative and absolute paths follow the MCP Python SDK contract.
- Remote SSE and Streamable HTTP servers remain unchanged.

## Validation
- `uv run --frozen --python 3.11 pytest -q` (34 passed)
- `uv run --frozen --python 3.11 python -m compileall -q src`
- `uv build --no-sources`
- Focused Ruff import and format checks
- README config parsing after removing its existing comments
- Live Xquik OAuth issuer, registration, and resource metadata
- GitHub Markdown rendering
- `git diff --check`

## Security
- `cwd` reaches the SDK as data without shell interpolation.
- The Xquik example uses OAuth dynamic client registration.
- No credential appears in the example or repository.

# Changelog Entry

### Added
- Add optional `cwd` support for stdio server configurations.
- Add an OAuth 2.1 Xquik configuration example.

### Changed
- Prefer OAuth over a committed bearer-key placeholder for Xquik.

### Fixed
- Allow configured stdio child processes to start in their required directory.
