### PR TITLE
fix: mcp version upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ requires-python = ">=3.11"
 dependencies = [
     "click>=8.1.8",
     "fastapi>=0.115.12",
-    "mcp>=1.17.0",
-    "mcp[cli]>=1.17.0",
+    "mcp>=1.17.0,<2",
+    "mcp[cli]>=1.17.0,<2",
     "passlib[bcrypt]>=1.7.4",
     "pydantic>=2.11.1",
     "pyjwt[crypto]>=2.10.1",


### PR DESCRIPTION

Fixes #303 : Current latest mcp version is currently not supported by mcpo, resulting in mcpo failing to build. Until more robust updates are implemented, the [suggested approach from python mcp sdk](https://github.com/modelcontextprotocol/python-sdk) should be followed: limiting major version to <2. 

**Changes:**
- Adds version limit of `,<2` to `mcp` and `mcp[cli]` in pyproject.toml dependency list.