### PR TITLE
feat: optionally preserve MCP tool names

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ That’s it. Your MCP tool is now available at http://localhost:8000 with a gene
 
 🤝 **To integrate with Open WebUI after launching the server, check our [docs](https://docs.openwebui.com/openapi-servers/open-webui/).**
 
+Use `--preserve-tool-names` to use MCP tool names as OpenAPI operation IDs.
+
 
 ### 🌐 Serving Under a Subpath (`--root-path`)
 

--- a/src/mcpo/__init__.py
+++ b/src/mcpo/__init__.py
@@ -72,6 +72,9 @@ def main(
     hot_reload: Annotated[
         Optional[bool], typer.Option("--hot-reload", help="Enable hot reload for config file changes")
     ] = False,
+    preserve_tool_names: Annotated[
+        Optional[bool], typer.Option("--preserve-tool-names", help="Use MCP tool names as OpenAPI operation IDs")
+    ] = False,
     log_level: Annotated[
         Optional[str], typer.Option("--log-level", help="Set log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)")
     ] = None,
@@ -152,6 +155,7 @@ def main(
             root_path=root_path,
             headers=headers,
             hot_reload=hot_reload,
+            preserve_tool_names=preserve_tool_names,
         )
     )
 

--- a/src/mcpo/main.py
+++ b/src/mcpo/main.py
@@ -260,6 +260,7 @@ def create_sub_app(
     api_dependency,
     connection_timeout,
     lifespan,
+    preserve_tool_names: bool = False,
 ) -> FastAPI:
     """Create a sub-application for an MCP server."""
     sub_app = FastAPI(
@@ -309,6 +310,7 @@ def create_sub_app(
 
     sub_app.state.api_dependency = api_dependency
     sub_app.state.connection_timeout = connection_timeout
+    sub_app.state.preserve_tool_names = preserve_tool_names
 
     # Store list of tools to be disabled, if present (accept both key styles)
     disabled_tools = server_cfg.get("disabledTools")
@@ -339,6 +341,7 @@ def mount_config_servers(
     connection_timeout,
     lifespan,
     path_prefix: str,
+    preserve_tool_names: bool = False,
 ):
     """Mount MCP servers from config data."""
     mcp_servers = config_data.get("mcpServers", {})
@@ -354,6 +357,7 @@ def mount_config_servers(
             api_dependency,
             connection_timeout,
             lifespan,
+            preserve_tool_names,
         )
         main_app.mount(f"{path_prefix}{server_name}", sub_app)
 
@@ -399,6 +403,7 @@ async def reload_config_handler(main_app: FastAPI, new_config_data: Dict[str, An
         connection_timeout = getattr(main_app.state, "connection_timeout", None)
         lifespan = getattr(main_app.state, "lifespan", None)
         path_prefix = getattr(main_app.state, "path_prefix", "/")
+        preserve_tool_names = getattr(main_app.state, "preserve_tool_names", False)
 
         # Remove servers that are no longer in config
         if servers_to_remove:
@@ -439,6 +444,7 @@ async def reload_config_handler(main_app: FastAPI, new_config_data: Dict[str, An
                         api_dependency,
                         connection_timeout,
                         lifespan,
+                        preserve_tool_names,
                     )
                     main_app.mount(f"{path_prefix}{server_name}", sub_app)
 
@@ -568,6 +574,9 @@ async def create_dynamic_endpoints(app: FastAPI, api_dependency=None):
             description=endpoint_description,
             response_model_exclude_none=True,
             dependencies=[Depends(api_dependency)] if api_dependency else [],
+            operation_id=endpoint_name
+            if getattr(app.state, "preserve_tool_names", False)
+            else None,
         )(tool_handler)
 
 
@@ -744,6 +753,7 @@ async def run(
     **kwargs,
 ):
     hot_reload = kwargs.get("hot_reload", False)
+    preserve_tool_names = kwargs.get("preserve_tool_names", False)
     # Server API Key
     api_dependency = get_verify_api_key(api_key) if api_key else None
     connection_timeout = kwargs.get("connection_timeout", None)
@@ -823,6 +833,7 @@ async def run(
     # Pass shutdown handler to app state
     main_app.state.shutdown_handler = shutdown_handler
     main_app.state.path_prefix = path_prefix
+    main_app.state.preserve_tool_names = preserve_tool_names
 
     main_app.add_middleware(
         CORSMiddleware,
@@ -882,6 +893,7 @@ async def run(
             connection_timeout,
             lifespan,
             path_prefix,
+            preserve_tool_names,
         )
 
         # Store config info and app state for hot reload

--- a/src/mcpo/tests/test_main.py
+++ b/src/mcpo/tests/test_main.py
@@ -1,7 +1,12 @@
-import pytest
-from pydantic import BaseModel, Field
+from types import SimpleNamespace
 from typing import Any, List, Dict, Union
+from unittest.mock import AsyncMock
 
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from mcpo.main import create_dynamic_endpoints
 from mcpo.utils.main import _process_schema_property
 
 
@@ -13,6 +18,34 @@ def clear_model_cache():
     _model_cache.clear()
     yield
     _model_cache.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("preserve_tool_names", "expected"),
+    [(False, "tool_firecrawl_search_post"), (True, "firecrawl_search")],
+)
+async def test_operation_id(preserve_tool_names, expected):
+    app = FastAPI()
+    app.state.preserve_tool_names = preserve_tool_names
+    app.state.session = AsyncMock()
+    app.state.session.initialize.return_value = SimpleNamespace(
+        serverInfo=None, instructions=None
+    )
+    app.state.session.list_tools.return_value = SimpleNamespace(
+        tools=[
+            SimpleNamespace(
+                name="firecrawl_search",
+                description="Search the web",
+                inputSchema={"type": "object", "properties": {}},
+                outputSchema=None,
+            )
+        ]
+    )
+
+    await create_dynamic_endpoints(app)
+
+    assert app.openapi()["paths"]["/firecrawl_search"]["post"]["operationId"] == expected
 
 
 def test_process_simple_string_required():


### PR DESCRIPTION
# Pull Request Checklist

- [x] Target branch: `dev`
- [x] No new dependencies
- [x] Tests added and passing
- [x] Self-reviewed
  - I have a patched version of the MCPO container running this exact code and tested with open-webui v0.10.2 

# Description
For example, Firecrawl exposes an MCP tool named `firecrawl_search`. MCPO normally generates the OpenAPI operation ID `tool_firecrawl_search_post`; with `--preserve-tool-names`, it remains `firecrawl_search`.

**Default behavior:**
<img width="405" height="106" alt="Screenshot 2026-08-20 at 2 35 14 PM" src="https://github.com/user-attachments/assets/ec5d22d3-9249-4c5e-ad1f-d043001af0a1" />

**With "--preserve-tool-names":**
<img width="320" height="71" alt="Screenshot 2026-08-20 at 2 35 22 PM" src="https://github.com/user-attachments/assets/2e41cf18-f639-4645-b74b-e89bfcdc2432" />



# Changelog Entry

### Description
Add an opt-in `--preserve-tool-names` flag that uses the original MCP tool name as the OpenAPI `operationId`. The current generated operation IDs remain the default.

### Added
- Optional MCP tool name preservation for OpenAPI operation IDs.