### PR TITLE
fix: reconnect when server invalidates the MCP session (404)

### DIFF
--- a/src/mcpo/tests/test_reconnect.py
+++ b/src/mcpo/tests/test_reconnect.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from mcp.shared.exceptions import McpError
+from mcp.types import CallToolResult, ErrorData, INTERNAL_ERROR, INVALID_REQUEST, TextContent
+
+# The bare positive code the python-sdk's StreamableHTTPTransport actually
+# hardcodes for a synthesized session-terminated error — NOT the negative
+# mcp.types.INVALID_REQUEST value (see _is_session_terminated in mcpo.utils.main).
+SESSION_TERMINATED_CODE = 32600
+
+from mcpo.utils.main import get_tool_handler
+
+
+def _make_request(session_manager):
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(session_manager=session_manager))
+    )
+
+
+def _success_result(text="ok"):
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+@pytest.mark.asyncio
+async def test_reconnects_on_synthesized_session_terminated_error():
+    """The python-sdk synthesizes McpError(INVALID_REQUEST, "Session terminated")
+    when the server 404s an existing session_id (see streamable_http.py). mcpo must
+    treat this the same as a ClosedResourceError and retry once against a fresh session."""
+    stale_session = AsyncMock()
+    stale_session.call_tool.side_effect = McpError(
+        ErrorData(code=SESSION_TERMINATED_CODE, message="Session terminated")
+    )
+
+    fresh_session = AsyncMock()
+    fresh_session.call_tool.return_value = _success_result()
+
+    session_manager = AsyncMock()
+    session_manager.ensure_initialized.return_value = (stale_session, None)
+    session_manager.reconnect.return_value = (fresh_session, None)
+
+    tool = get_tool_handler("do_thing", form_model_fields=None)
+    request = _make_request(session_manager)
+
+    result = await tool(request)
+
+    assert result == "ok"
+    session_manager.reconnect.assert_awaited_once()
+    fresh_session.call_tool.assert_awaited_once_with("do_thing", arguments={})
+
+
+@pytest.mark.asyncio
+async def test_does_not_reconnect_on_unrelated_mcp_error():
+    """A real tool-level/server-originated McpError must propagate as-is, not
+    trigger a reconnect+retry."""
+    session = AsyncMock()
+    session.call_tool.side_effect = McpError(
+        ErrorData(code=INTERNAL_ERROR, message="tool blew up")
+    )
+
+    session_manager = AsyncMock()
+    session_manager.ensure_initialized.return_value = (session, None)
+
+    tool = get_tool_handler("do_thing", form_model_fields=None)
+    request = _make_request(session_manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tool(request)
+
+    assert exc_info.value.status_code == 500
+    session_manager.reconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_does_not_reconnect_on_real_invalid_request_error():
+    """A genuine JSON-RPC INVALID_REQUEST (-32600) with a different message is
+    a real protocol error, not the synthesized session-terminated signal —
+    must not trigger a reconnect."""
+    session = AsyncMock()
+    session.call_tool.side_effect = McpError(
+        ErrorData(code=INVALID_REQUEST, message="Malformed request")
+    )
+
+    session_manager = AsyncMock()
+    session_manager.ensure_initialized.return_value = (session, None)
+
+    tool = get_tool_handler("do_thing", form_model_fields=None)
+    request = _make_request(session_manager)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tool(request)
+
+    assert exc_info.value.status_code == 400
+    session_manager.reconnect.assert_not_awaited()

--- a/src/mcpo/utils/main.py
+++ b/src/mcpo/utils/main.py
@@ -34,6 +34,25 @@ MCP_ERROR_TO_HTTP_STATUS = {
 logger = logging.getLogger(__name__)
 
 
+# python-sdk's StreamableHTTPTransport synthesizes this exact error on ANY
+# HTTP 404 response, discarding whatever JSON-RPC error body the server sent
+# (see _send_session_terminated_error in mcp/client/streamable_http.py). Note
+# it hardcodes a bare positive 32600, not the negative -32600 that
+# mcp.types.INVALID_REQUEST holds per the JSON-RPC spec — matching against
+# INVALID_REQUEST here would never fire.
+_SESSION_TERMINATED_CODE = 32600
+_SESSION_TERMINATED_MESSAGE = "Session terminated"
+
+
+def _is_session_terminated(exc: McpError) -> bool:
+    """True only for the client-synthesized 404-on-existing-session signal —
+    never a real tool-level or server-originated JSON-RPC error."""
+    return (
+        exc.error.code == _SESSION_TERMINATED_CODE
+        and exc.error.message == _SESSION_TERMINATED_MESSAGE
+    )
+
+
 def normalize_server_type(server_type: str) -> str:
     """Normalize server_type to a standard value."""
     if server_type in ["streamable_http", "streamablehttp", "streamable-http"]:
@@ -303,9 +322,11 @@ def get_tool_handler(
 
             try:
                 return await _invoke(session)
-            except ClosedResourceError:
+            except (ClosedResourceError, McpError) as e:
+                if isinstance(e, McpError) and not _is_session_terminated(e):
+                    raise
                 logger.warning(
-                    "Session closed during call to '%s'; attempting reconnect",
+                    "Session closed/terminated during call to '%s'; attempting reconnect",
                     endpoint_name,
                 )
                 session, _ = await session_manager.reconnect()


### PR DESCRIPTION
## Problem

`call_tool_with_reconnect()` only retries on `ClosedResourceError` (a transport-level failure). When the upstream MCP server invalidates a session server-side — TTL expiry on a `FileSessionStore`-backed server, a restart, etc. — and returns a 404, that surfaces as a hard error to the mcpo client instead of transparently reconnecting, even though `MCPConnectionManager.reconnect()` already exists and handles the transport-failure case fine.

Real-world traceback we hit in production:

```
mcp.shared.exceptions.McpError: Session terminated
```

which mcpo currently turns into an HTTP error response instead of retrying.

## Root cause

python-sdk's `StreamableHTTPTransport` synthesizes `McpError(code=32600, message="Session terminated")` on **any** HTTP 404 response to a JSON-RPC request, discarding whatever error body the server actually sent (see [`_send_session_terminated_error`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/streamable_http.py) in `mcp/client/streamable_http.py`, called unconditionally from `_handle_post_request` on `status_code == 404`).

One subtlety worth flagging explicitly: that `32600` is a bare **positive** literal hardcoded by the SDK — it is *not* `mcp.types.INVALID_REQUEST` (`-32600`, the JSON-RPC-spec-correct signed value). Matching against the typed constant would silently never fire; the fix matches the literal value the SDK actually emits, with a comment explaining why.

## Fix

Catch that specific `McpError` (matched on `code == 32600 and message == "Session terminated"`) alongside `ClosedResourceError` in `call_tool_with_reconnect()`'s retry path, and retry once against a freshly reconnected session. Any other `McpError` — a real tool-level or protocol error — still propagates unchanged.

The `ensure_initialized()` call path (before any session exists) does not need the same treatment: the synthesized error can only occur on a request carrying an already-established `session_id`.

## Testing

- Added `src/mcpo/tests/test_reconnect.py`: positive case (synthesized session-terminated error triggers exactly one reconnect + successful retry) and two negative cases (an unrelated `McpError`, and — to guard against the code-sign mixup above recurring — a *real* `INVALID_REQUEST` (-32600) error with a different message) confirm reconnection is not triggered for either.
- Full suite passes (30/30).
- Verified end-to-end against a local streamable-http MCP server (PHP, `mcp/sdk`-based, `FileSessionStore`): built mcpo from this branch, established a session, deleted the session's backing file to force the server to 404 on the next call, and confirmed the unpatched code returns a 500 to the mcpo client while this patch transparently negotiates a new session and completes the call.

Assisted with Claude Code